### PR TITLE
Connect RPG sheets to combatants on battlemap

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -262,6 +262,7 @@ import { DonateComponent } from './pages/donate/donate.component';
 import { SharingModalComponent } from './components/common/sharing-modal/sharing-modal.component';
 import { BattlemapActiveCardDnd5eComponent } from './pages/battlemaps/active-card/dnd5e/dnd5e.component';
 import { BattlemapActiveCardPathfinderComponent } from './pages/battlemaps/active-card/pathfinder/pathfinder.component';
+import { BattlemapActiveCardRpgComponent } from './pages/battlemaps/active-card/rpg/rpg.component';
 import { HomebrewKitsComponent } from './pages/homebrew-kits/homebrew-kits.component';
 import { AccountComponent } from './pages/account/account.component';
 import { HomebrewKitCollectionComponent } from './pages/homebrew-kits/collection/collection.component';
@@ -300,6 +301,7 @@ import { BattlemapDetailLayerComponent } from './pages/battlemaps/detail/layer/l
 import { Dnd5eEditAttackComponent } from './pages/dnd5e-sheets/components/attack/attack.component';
 import { BattlemapDetailCombatantComponent } from './pages/battlemaps/detail/combatant/combatant.component';
 import { BattlemapDetailOwnerComponent } from './pages/battlemaps/detail/owner/owner.component';
+import { RpgOverviewTabComponent } from './pages/rpg-sheets/overview/tab/tab.component';
 
 export function markedOptionsFactory(): MarkedOptions {
   const renderer = new MarkedRenderer();
@@ -514,6 +516,7 @@ export function markedOptionsFactory(): MarkedOptions {
     SharingModalComponent,
     BattlemapActiveCardDnd5eComponent,
     BattlemapActiveCardPathfinderComponent,
+    BattlemapActiveCardRpgComponent,
     HomebrewKitsComponent,
     AccountComponent,
     HomebrewKitCollectionComponent,
@@ -551,6 +554,7 @@ export function markedOptionsFactory(): MarkedOptions {
     Dnd5eEditAttackComponent,
     BattlemapDetailCombatantComponent,
     BattlemapDetailOwnerComponent,
+    RpgOverviewTabComponent,
   ],
   imports: [
     BrowserModule,

--- a/src/app/models/rpg/base.ts
+++ b/src/app/models/rpg/base.ts
@@ -50,6 +50,13 @@ export class RpgCharacter extends BtBase {
               size: 6,
             }),
           ]
+        }),
+        new RpgTab({
+          name: 'Battlemap',
+          sections: [
+            new RpgTabSection({ size: 6 }),
+            new RpgTabSection({ size: 6 }),
+          ]
         })
       ],
 

--- a/src/app/models/rpg/base.ts
+++ b/src/app/models/rpg/base.ts
@@ -53,8 +53,8 @@ export class RpgCharacter extends BtBase {
         new RpgTab({
           name: 'Battlemap',
           sections: [
-            new RpgTabSection({ size: 6 }),
-            new RpgTabSection({ size: 6 }),
+            new RpgTabSection({ size: 6, overview: false }),
+            new RpgTabSection({ size: 6, overview: false }),
           ]
         })
       ],

--- a/src/app/models/rpg/base.ts
+++ b/src/app/models/rpg/base.ts
@@ -53,8 +53,8 @@ export class RpgCharacter extends BtBase {
         new RpgTab({
           name: 'Battlemap',
           sections: [
-            new RpgTabSection({ size: 6, overview: false }),
-            new RpgTabSection({ size: 6, overview: false }),
+            new RpgTabSection({ size: 6 }),
+            new RpgTabSection({ size: 6 }),
           ]
         })
       ],

--- a/src/app/models/rpg/base.ts
+++ b/src/app/models/rpg/base.ts
@@ -39,14 +39,13 @@ export class RpgCharacter extends BtBase {
       tabs: [
         new RpgTab({
           name: 'Example Tab',
-          id: 'TABIDIS12345',
           sections: [
             new RpgTabSection({
-              id: 'SECTIONIDIS0',
+              entity_ids: ['123456789012', '123456789013', '123456789014'],
               size: 6,
             }),
             new RpgTabSection({
-              id: 'SECTIONIDIS1',
+              entity_ids: ['COLLECTION01', 'CONDITION001'],
               size: 6,
             }),
           ]
@@ -62,33 +61,28 @@ export class RpgCharacter extends BtBase {
 
       stats: [
         new RpgStat({
-          name: 'Total HP',
           id: '123456789012',
-          tab: 'TABIDIS12345',
-          section: 'SECTIONIDIS0',
+          name: 'Total HP',
         }),
         new RpgStat({
+          id: '123456789013',
           name: 'Wounds',
-          tab: 'TABIDIS12345',
-          section: 'SECTIONIDIS0',
         }),
       ],
 
       calculations: [
         new RpgCalculation({
+          id: '123456789014',
           name: 'Current HP',
           formula: '{Total HP} - {Wounds}',
-          tab: 'TABIDIS12345',
-          section: 'SECTIONIDIS0',
         })
       ],
 
       collections: [
         new RpgCollection({
+          id: 'COLLECTION01',
           name: 'Spells',
           collectable: 'ZXCQWEEUIORT',
-          tab: 'TABIDIS12345',
-          section: 'SECTIONIDIS1',
           items: [
             new RpgCollectionItem({
               name: 'Magic Missile',
@@ -128,9 +122,8 @@ export class RpgCharacter extends BtBase {
 
       conditions: [
         new RpgCondition({
+          id: 'CONDITION001',
           name: 'Dead',
-          tab: 'TABIDIS12345',
-          section: 'SECTIONIDIS1',
           effects: [
             new RpgConditionEffect({
               stat: '123456789012',

--- a/src/app/models/rpg/base.ts
+++ b/src/app/models/rpg/base.ts
@@ -27,7 +27,7 @@ export class RpgCharacter extends BtBase {
 
   getProto() {
     return {
-      version: 0,
+      version: 1,
       name: 'New RPG Sheet',
       change_id: '0',
       oversized: false,

--- a/src/app/models/rpg/calculation.ts
+++ b/src/app/models/rpg/calculation.ts
@@ -4,8 +4,6 @@ export class RpgCalculation extends BtBase {
   pos: number
   name: string
   formula: string
-  tab: string
-  section: string
   rolls: boolean
   valid: boolean
 
@@ -14,8 +12,6 @@ export class RpgCalculation extends BtBase {
       pos: 0,
       name: null,
       formula: null,
-      tab: null,
-      section: null,
       rolls: false,
       valid: true,
       // phrase: null,

--- a/src/app/models/rpg/calculation.ts
+++ b/src/app/models/rpg/calculation.ts
@@ -9,7 +9,6 @@ export class RpgCalculation extends BtBase {
 
   getProto() {
     return {
-      pos: 0,
       name: null,
       formula: null,
       rolls: false,

--- a/src/app/models/rpg/collectable-field.ts
+++ b/src/app/models/rpg/collectable-field.ts
@@ -7,6 +7,7 @@ export class RpgCollectableField extends BtBase {
   input_type: string
   width: string
   space: string
+  overview: boolean
   formula: string
   error: any
   valid: boolean
@@ -20,6 +21,7 @@ export class RpgCollectableField extends BtBase {
       input_type: 'text',
       width: 'dynamic',
       space: 'none',
+      overview: true,
       formula: null,
       error: null,
       valid: true,

--- a/src/app/models/rpg/collection.ts
+++ b/src/app/models/rpg/collection.ts
@@ -4,8 +4,6 @@ import { RpgCollectionItem } from './collection-item'
 export class RpgCollection extends BtBase {
   pos: number
   name: string
-  tab: string
-  section: string
   collectable: string
   items: RpgCollectionItem[]
 
@@ -13,8 +11,6 @@ export class RpgCollection extends BtBase {
     return {
       pos: 0,
       name: null,
-      tab: null,
-      section: null,
       collectable: null,
       items: []
     }

--- a/src/app/models/rpg/collection.ts
+++ b/src/app/models/rpg/collection.ts
@@ -9,7 +9,6 @@ export class RpgCollection extends BtBase {
 
   getProto() {
     return {
-      pos: 0,
       name: null,
       collectable: null,
       items: []

--- a/src/app/models/rpg/condition.ts
+++ b/src/app/models/rpg/condition.ts
@@ -10,7 +10,6 @@ export class RpgCondition extends BtBase {
 
   getProto() {
     return {
-      pos: 0,
       name: '',
       description: null,
       active: false,

--- a/src/app/models/rpg/condition.ts
+++ b/src/app/models/rpg/condition.ts
@@ -6,8 +6,6 @@ export class RpgCondition extends BtBase {
   name: string
   description: string
   active: boolean
-  tab: string
-  section: string
   effects: RpgConditionEffect[]
 
   getProto() {
@@ -16,8 +14,6 @@ export class RpgCondition extends BtBase {
       name: '',
       description: null,
       active: false,
-      tab: null,
-      section: null,
       effects: []
     }
   }

--- a/src/app/models/rpg/stat.ts
+++ b/src/app/models/rpg/stat.ts
@@ -10,7 +10,6 @@ export class RpgStat extends BtBase {
 
   getProto() {
     return {
-      pos: 0,
       name: null,
       value: 0,
       auto: null,

--- a/src/app/models/rpg/stat.ts
+++ b/src/app/models/rpg/stat.ts
@@ -7,8 +7,6 @@ export class RpgStat extends BtBase {
   auto: number
   input_type: string
   source: string
-  tab: string
-  section: string
 
   getProto() {
     return {
@@ -18,8 +16,6 @@ export class RpgStat extends BtBase {
       auto: null,
       input_type: 'number',
       source: null,
-      tab: null,
-      section: null,
     }
   }
 }

--- a/src/app/models/rpg/tab-section.ts
+++ b/src/app/models/rpg/tab-section.ts
@@ -4,12 +4,14 @@ export class RpgTabSection extends BtBase {
   pos: number
   size: number
   overview: boolean
+  entity_ids: string[]
 
   getProto() {
     return {
       pos: 0,
       size: 12,
       overview: true,
+      entity_ids: null,
     }
   }
 }

--- a/src/app/pages/battlemaps/active-card/active-card.component.html
+++ b/src/app/pages/battlemaps/active-card/active-card.component.html
@@ -3,6 +3,7 @@
     <div [ngSwitch]="combatant.type">
       <bt-battlemap-active-card-dnd5e      [self]="self" [sheet]="self.methods.connectedCombatantSheet(combatant)" *ngSwitchCase="'dnd5e'"></bt-battlemap-active-card-dnd5e>
       <bt-battlemap-active-card-pathfinder [self]="self" [sheet]="self.methods.connectedCombatantSheet(combatant)" *ngSwitchCase="'pathfinder'"></bt-battlemap-active-card-pathfinder>
+      <bt-battlemap-active-card-rpg        [self]="self" [sheet]="self.methods.connectedCombatantSheet(combatant)" *ngSwitchCase="'rpg'"></bt-battlemap-active-card-rpg>
       <bt-battlemap-active-card-custom     [self]="self" [token]="token" [combatant]="combatant" *ngSwitchDefault></bt-battlemap-active-card-custom>
     </div>
   </div>
@@ -39,11 +40,14 @@
   <h2 class="h18 bm-10">Setup {{ combatant.name }} :: Connect or enter data manually</h2>
   <div class="flex-row-all flex-gutters-5">
     <ng-container *ngIf="token else no_token">
-      <div class="flex-col-4" *ngIf="token">
+      <div class="flex-col-4">
         <button class="button button-cyan button-block" (click)="setCombatantType('dnd5e')">Connect to D&D 5e Sheet</button>
       </div>
-      <div class="flex-col-4" *ngIf="token">
+      <div class="flex-col-4">
         <button class="button button-cyan button-block" (click)="setCombatantType('pathfinder')">Connect to Pathfinder Sheet</button>
+      </div>
+      <div class="flex-col-4">
+        <button class="button button-cyan button-block" (click)="setCombatantType('rpg')">Connect to RPG Sheet</button>
       </div>
     </ng-container>
     <div class="flex-col-4">

--- a/src/app/pages/battlemaps/active-card/rpg/rpg.component.html
+++ b/src/app/pages/battlemaps/active-card/rpg/rpg.component.html
@@ -1,0 +1,6 @@
+<div [class.bt-hide]="sheet.locals.ready">
+  <h2 class="h18 bm-10">Loading details, please wait...</h2>
+</div>
+<ng-container *ngIf="sheet.locals.ready">
+  <bt-rpg-overview-tab [self]="sheet" [tab]="sheet.methods.battlemapTab()"></bt-rpg-overview-tab>
+</ng-container>

--- a/src/app/pages/battlemaps/active-card/rpg/rpg.component.spec.ts
+++ b/src/app/pages/battlemaps/active-card/rpg/rpg.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { BattlemapActiveCardRpgComponent } from '././rpg.component'
+
+describe('BattlemapActiveCardRpgComponent', () => {
+  let component: BattlemapActiveCardRpgComponent;
+  let fixture: ComponentFixture<BattlemapActiveCardRpgComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ BattlemapActiveCardRpgComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(BattlemapActiveCardRpgComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/pages/battlemaps/active-card/rpg/rpg.component.ts
+++ b/src/app/pages/battlemaps/active-card/rpg/rpg.component.ts
@@ -1,0 +1,13 @@
+import { Component, Input } from '@angular/core';
+
+@Component({
+  selector: 'bt-battlemap-active-card-rpg',
+  templateUrl: './rpg.component.html',
+  styleUrls: ['./rpg.component.scss']
+})
+export class BattlemapActiveCardRpgComponent {
+  @Input() public self: any
+  @Input() public sheet: any
+
+  constructor() { }
+}

--- a/src/app/pages/battlemaps/battlemaps.component.ts
+++ b/src/app/pages/battlemaps/battlemaps.component.ts
@@ -29,7 +29,7 @@ export class BattlemapsComponent implements OnInit, OnDestroy {
       switchMap(() => {
         return this.store.setupToolController(this.self, 'battlemap', [
           map((tools: BtPlayerTool[]) => tools.filter(tool => {
-            return ['pathfinder', 'dnd5e'].includes(tool.tool_type) && ['owner', 'writer'].includes(tool.role)
+            return ['pathfinder', 'dnd5e', 'rpg'].includes(tool.tool_type) && ['owner', 'writer'].includes(tool.role)
           })),
           tap((tools: BtPlayerTool[]) => {
             tools.forEach(x => x.updated_at = x.updated_at || 0)

--- a/src/app/pages/rpg-sheets/entities/collection/collection.component.html
+++ b/src/app/pages/rpg-sheets/entities/collection/collection.component.html
@@ -1,14 +1,14 @@
-<div class="bm-40" *ngFor="let collectable of self.methods.$list(self.methods.getCollectableById(entity.collectable))">
+<div class="rpg-collection rpg-collection-edit" *ngFor="let collectable of self.methods.$list(self.methods.getCollectableById(entity.collectable))">
   <h2 class="gh3">{{ entity.name }}</h2>
-  <div class="collection-label-row bm-5" *ngIf="collectable.label_type === 'above'">
+  <div class="collection-label-row above-labels" *ngIf="collectable.label_type === 'above'">
     <div class="flex-row-all flex-gutters-5 flex-config-align-center flex-config-spaced">
       <div class="flex-col" *ngFor="let field of self.methods.listCollectableFields(collectable)" [ngClass]="self.methods.getCollectableFieldClasses(field)">
         <label class="control-label">{{ field.name }}</label>
       </div>
     </div>
   </div>
-  <div cdkDropList [cdkDropListData]="self.model.collection_items" (cdkDropListDropped)="self.methods.onSortableDrop($event)"> <!--todo sortable: [data-collection-id]="entity.id"-->
-    <div class="flex-row-all flex-gutters-5 bm-10 js-collection-item" *ngFor="let item of self.methods.listCollectionItems(entity)" cdkDrag [cdkDragData]="item">
+  <div cdkDropList [cdkDropListData]="self.model.collection_items" (cdkDropListDropped)="self.methods.onSortableDrop($event)">
+    <div class="flex-row-all flex-gutters-5 collection-item" *ngFor="let item of self.methods.listCollectionItems(entity)" cdkDrag [cdkDragData]="item">
       <div class="flex-col flex-static">
         <span class="drag-handle g-neutral" cdkDragHandle><i class="material-icons">menu</i></span>
       </div>

--- a/src/app/pages/rpg-sheets/overview/entities/calculation/calculation.component.html
+++ b/src/app/pages/rpg-sheets/overview/entities/calculation/calculation.component.html
@@ -1,4 +1,4 @@
-<div class="stat-number-row flex-gutters-5 bm-10">
+<div class="rpg-calculation stat-number-row flex-gutters-5">
   <div class="flex-col-4">
     <label class="block-label">{{ entity.name }}</label>
   </div>

--- a/src/app/pages/rpg-sheets/overview/entities/collection/collection.component.html
+++ b/src/app/pages/rpg-sheets/overview/entities/collection/collection.component.html
@@ -1,15 +1,15 @@
-<div class="bm-20" *ngFor="let collectable of self.methods.$list(self.methods.getCollectableById(entity.collectable))">
+<div class="rpg-collection" *ngFor="let collectable of self.methods.$list(self.methods.getCollectableById(entity.collectable))">
   <h2 class="gh4">{{ entity.name }}</h2>
-  <div class="bm-5" *ngIf="collectable.label_type === 'above'">
+  <div class="above-labels" *ngIf="collectable.label_type === 'above'">
     <div class="flex-row-all flex-gutters-5 flex-config-align-center flex-config-spaced">
-      <div class="flex-col" *ngFor="let field of self.methods.listCollectableFields(collectable)" [ngClass]="self.methods.getCollectableFieldClasses(field)">
+      <div class="flex-col" *ngFor="let field of self.methods.listCollectableFieldsForOverview(collectable)" [ngClass]="self.methods.getCollectableFieldClasses(field)">
         <label class="control-label">{{ field.name }}</label>
       </div>
     </div>
   </div>
-  <div class="bm-10 js-collection-item" *ngFor="let item of self.methods.listCollectionItems(entity)">
+  <div class="collection-item" *ngFor="let item of self.methods.listCollectionItems(entity)">
     <div class="flex-row-all flex-gutters-5 flex-config-wrap flex-config-align-center flex-config-spaced">
-      <div class="flex-col" [ngSwitch]="field.input_type" *ngFor="let field of self.methods.listCollectableFields(collectable)" [ngClass]="self.methods.getCollectableFieldClasses(field)">
+      <div class="flex-col" [ngSwitch]="field.input_type" *ngFor="let field of self.methods.listCollectableFieldsForOverview(collectable)" [ngClass]="self.methods.getCollectableFieldClasses(field)">
         <bt-rpg-overview-collectable-type-boolean    [self]="self" [field]="field" [item]="item" [collectable]="collectable" *ngSwitchCase="'boolean'"></bt-rpg-overview-collectable-type-boolean>
         <bt-rpg-overview-collectable-type-formula    [self]="self" [field]="field" [item]="item" [collectable]="collectable" *ngSwitchCase="'formula'"></bt-rpg-overview-collectable-type-formula>
         <bt-rpg-overview-collectable-type-reference  [self]="self" [field]="field" [item]="item" [collectable]="collectable" *ngSwitchCase="'reference'"></bt-rpg-overview-collectable-type-reference>

--- a/src/app/pages/rpg-sheets/overview/entities/condition/condition.component.html
+++ b/src/app/pages/rpg-sheets/overview/entities/condition/condition.component.html
@@ -1,4 +1,4 @@
-<div class="bm-10">
+<div class="rpg-condition">
   <label class="checkbox-inline">
     <input type="checkbox" title="Toggle {{ entity.name }}" (ngModelChange)="self.methods.toggleCondition(entity)" [(ngModel)]="entity.active">
     <span>{{ entity.name }}</span>

--- a/src/app/pages/rpg-sheets/overview/entities/stat/stat.component.html
+++ b/src/app/pages/rpg-sheets/overview/entities/stat/stat.component.html
@@ -1,4 +1,4 @@
-<div class="stat-number-row flex-gutters-5 bm-10">
+<div class="rpg-stat stat-number-row flex-gutters-5">
   <div class="flex-col-4">
     <label class="control-label">{{ entity.name }}</label>
   </div>

--- a/src/app/pages/rpg-sheets/overview/tab/tab.component.html
+++ b/src/app/pages/rpg-sheets/overview/tab/tab.component.html
@@ -1,0 +1,12 @@
+<div class="flex-row-tablet flex-gutters-15 flex-config-wrap" *ngIf="tab">
+  <div class="overview-display-section section" *ngFor="let section of self.methods.listTabSectionsForOverview(tab)" [ngClass]="self.methods.getTabSectionClass(section)">
+    <div *ngFor="let entity of self.methods.listEntitiesByGrouping(tab.id, section.id)">
+      <div [ngSwitch]="self.methods.getEntityType(entity)">
+        <bt-rpg-overview-entity-calculation  [self]="self" [entity]="entity" *ngSwitchCase="'RpgCalculation'"></bt-rpg-overview-entity-calculation>
+        <bt-rpg-overview-entity-collection   [self]="self" [entity]="entity" *ngSwitchCase="'RpgCollection'"></bt-rpg-overview-entity-collection>
+        <bt-rpg-overview-entity-condition    [self]="self" [entity]="entity" *ngSwitchCase="'RpgCondition'"></bt-rpg-overview-entity-condition>
+        <bt-rpg-overview-entity-stat         [self]="self" [entity]="entity" *ngSwitchCase="'RpgStat'"></bt-rpg-overview-entity-stat>
+      </div>
+    </div>
+  </div>
+</div>

--- a/src/app/pages/rpg-sheets/overview/tab/tab.component.html
+++ b/src/app/pages/rpg-sheets/overview/tab/tab.component.html
@@ -1,6 +1,6 @@
 <div class="flex-row-tablet flex-gutters-15 flex-config-wrap" *ngIf="tab">
   <div class="overview-display-section section" *ngFor="let section of self.methods.listTabSectionsForOverview(tab)" [ngClass]="self.methods.getTabSectionClass(section)">
-    <div *ngFor="let entity of self.methods.listEntitiesByGrouping(tab.id, section.id)">
+    <div *ngFor="let entity of self.methods.listEntitiesBySection(section)">
       <div [ngSwitch]="self.methods.getEntityType(entity)">
         <bt-rpg-overview-entity-calculation  [self]="self" [entity]="entity" *ngSwitchCase="'RpgCalculation'"></bt-rpg-overview-entity-calculation>
         <bt-rpg-overview-entity-collection   [self]="self" [entity]="entity" *ngSwitchCase="'RpgCollection'"></bt-rpg-overview-entity-collection>

--- a/src/app/pages/rpg-sheets/overview/tab/tab.component.html
+++ b/src/app/pages/rpg-sheets/overview/tab/tab.component.html
@@ -6,6 +6,7 @@
         <bt-rpg-overview-entity-collection   [self]="self" [entity]="entity" *ngSwitchCase="'RpgCollection'"></bt-rpg-overview-entity-collection>
         <bt-rpg-overview-entity-condition    [self]="self" [entity]="entity" *ngSwitchCase="'RpgCondition'"></bt-rpg-overview-entity-condition>
         <bt-rpg-overview-entity-stat         [self]="self" [entity]="entity" *ngSwitchCase="'RpgStat'"></bt-rpg-overview-entity-stat>
+        <ng-container *ngSwitchDefault>No known input for this type</ng-container>
       </div>
     </div>
   </div>

--- a/src/app/pages/rpg-sheets/overview/tab/tab.component.spec.ts
+++ b/src/app/pages/rpg-sheets/overview/tab/tab.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { RpgOverviewTabComponent } from './tab.component'
+
+describe('RpgOverviewTabComponent', () => {
+  let component: RpgOverviewTabComponent;
+  let fixture: ComponentFixture<RpgOverviewTabComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ RpgOverviewTabComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(RpgOverviewTabComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/pages/rpg-sheets/overview/tab/tab.component.ts
+++ b/src/app/pages/rpg-sheets/overview/tab/tab.component.ts
@@ -1,0 +1,12 @@
+import { Component, Input } from '@angular/core';
+
+@Component({
+  selector: 'bt-rpg-overview-tab',
+  templateUrl: './tab.component.html',
+  styleUrls: ['./tab.component.scss']
+})
+export class RpgOverviewTabComponent {
+  @Input() public self: any
+  @Input() public tab: any
+  constructor() { }
+}

--- a/src/app/pages/rpg-sheets/rpg-sheets.component.html
+++ b/src/app/pages/rpg-sheets/rpg-sheets.component.html
@@ -35,9 +35,7 @@ OVERVIEW TAB
 
       <div class="tab overview-tab" [class.active]="self.methods.isTabActive('overview')">
         <div class="overview-display-tab" *ngFor="let tab of self.methods.listTabs()">
-          <div class="flex-row-tablet flex-gutters-15 flex-config-wrap">
-            <bt-rpg-overview-tab [self]="self" [tab]="tab"></bt-rpg-overview-tab>
-          </div>
+          <bt-rpg-overview-tab [self]="self" [tab]="tab"></bt-rpg-overview-tab>
         </div>
       </div>
 
@@ -107,11 +105,11 @@ STRUCTURE TAB
                   <h2 class="gh2">Fields for section <span>{{ section.pos + 1 }}</span> of <span>{{ tab.name }}</span></h2>
                   <div class="structure-section-fields"
                     cdkDropList
-                    [cdkDropListData]="self.methods.listEntitiesByGrouping(tab.id, section.id)"
+                    [cdkDropListData]="self.methods.listEntitiesBySection(section)"
                     (cdkDropListDropped)="self.methods.onMoveList(tab.id, section.id, $event)"
                   >
-                    <p *ngIf="!self.methods.anyEntitiesByGrouping(tab.id, section.id)" class="p3">There are no fields assigned to this section. Drag fields into here!</p>
-                    <div class="structure-field js-structure-field flex-row-all flex-config-spaced flex-config-align-center" *ngFor="let entity of self.methods.listEntitiesByGrouping(tab.id, section.id)" cdkDrag [cdkDragData]="entity">
+                    <p *ngIf="!self.methods.anyEntitiesBySection(section)" class="p3">There are no fields assigned to this section. Drag fields into here!</p>
+                    <div class="structure-field js-structure-field flex-row-all flex-config-spaced flex-config-align-center" *ngFor="let entity of self.methods.listEntitiesBySection(section)" cdkDrag [cdkDragData]="entity">
                       <!-- todo:  [data-id]="entity.id" [data-entity-type]="self.methods.getEntityType(entity)" -->
                       <span class="name">{{ entity.name }}</span>
                       <span class="info">{{ self.methods.getEntityInfo(entity) }}</span>
@@ -123,10 +121,10 @@ STRUCTURE TAB
                   <div class="structure-section-fields"
                     cdkDropList
                     (cdkDropListDropped)="self.methods.onMoveList(null, null, $event)"
-                    [cdkDropListData]="self.methods.listEntitiesByGrouping(null, null)"
+                    [cdkDropListData]="self.methods.listEntitiesBySection()"
                   >
-                    <p *ngIf="!self.methods.anyEntitiesByGrouping(null, null)" class="p3">There are no unassigned fields. Create more on the Content tab or reassign from a different section.</p>
-                    <div class="structure-field js-structure-field flex-row-all flex-config-spaced flex-config-align-center" *ngFor="let entity of self.methods.listEntitiesByGrouping(null, null)" cdkDrag [cdkDragData]="entity">
+                    <p *ngIf="!self.methods.anyEntitiesBySection()" class="p3">There are no unassigned fields. Create more on the Content tab or reassign from a different section.</p>
+                    <div class="structure-field js-structure-field flex-row-all flex-config-spaced flex-config-align-center" *ngFor="let entity of self.methods.listEntitiesBySection(null)" cdkDrag [cdkDragData]="entity">
                       <!-- todo:  [data-id]="entity.id" [data-entity-type]="self.methods.getEntityType(entity)" -->
                       <span class="name">{{ entity.name }}</span>
                       <span class="info">{{ self.methods.getEntityInfo(entity) }}</span>
@@ -387,7 +385,7 @@ USER MODEL TAB
         <h2 class="group-header">{{ tab.name }}</h2>
         <div class="flex-row-tablet flex-gutters-15 flex-config-wrap">
           <div class="section" *ngFor="let section of self.methods.listTabSections(tab)" [ngClass]="self.methods.getTabSectionClass(section)">
-            <div [ngSwitch]="self.methods.getEntityType(entity)" *ngFor="let entity of self.methods.listEntitiesByGrouping(tab.id, section.id)">
+            <div [ngSwitch]="self.methods.getEntityType(entity)" *ngFor="let entity of self.methods.listEntitiesBySection(section)">
               <bt-rpg-entity-calculation  [self]="self" [entity]="entity" *ngSwitchCase="'RpgCalculation'"></bt-rpg-entity-calculation>
               <bt-rpg-entity-collection   [self]="self" [entity]="entity" *ngSwitchCase="'RpgCollection'"></bt-rpg-entity-collection>
               <bt-rpg-entity-condition    [self]="self" [entity]="entity" *ngSwitchCase="'RpgCondition'"></bt-rpg-entity-condition>

--- a/src/app/pages/rpg-sheets/rpg-sheets.component.html
+++ b/src/app/pages/rpg-sheets/rpg-sheets.component.html
@@ -34,7 +34,7 @@ OVERVIEW TAB
 -->
 
       <div class="tab overview-tab" [class.active]="self.methods.isTabActive('overview')">
-        <div class="overview-display-tab" *ngFor="let tab of self.methods.listTabs()">
+        <div class="overview-display-tab" *ngFor="let tab of self.methods.listIncludedTabs()">
           <bt-rpg-overview-tab [self]="self" [tab]="tab"></bt-rpg-overview-tab>
         </div>
       </div>
@@ -70,10 +70,11 @@ STRUCTURE TAB
 
           <div class="slide" [class.present]="self.methods.anyActiveTab()">
             <div *ngFor="let tab of self.methods.structureTabInArray()">
-              <div>
+              <div class="tm-20">
                 <h2 class="gh2"><span>{{ tab.name }}</span> Sections Layout</h2>
                 <div class="bm-20">
-                  <input type="text" placeholder="Tab name" (ngModelChange)="self.touch()" [(ngModel)]="tab.name" class="form-control">
+                  <p *ngIf="tab.name === 'Battlemap'" class="help-text">This is a special system-use tab that cannot be renamed. The data here is used to display on the Battlemap for tokens connected to this sheet.</p>
+                  <input *ngIf="tab.name !== 'Battlemap'" type="text" placeholder="Tab name" (ngModelChange)="self.touch()" [(ngModel)]="tab.name" class="form-control">
                 </div>
                 <div class="bm-20 flex-row-all flex-config-wrap flex-gutters-5" cdkDropList [cdkDropListData]="tab.sections" (cdkDropListDropped)="self.methods.onSortableDrop($event)">
                   <div class="js-structure-section bm-10" *ngFor="let section of self.methods.listTabSections(tab)" cdkDrag [cdkDragData]="section" [ngClass]="self.methods.getTabSectionClass(section)" (click)="self.methods.setStructureSection(section)">
@@ -372,6 +373,13 @@ CONTENT TAB
                               <option [value]="option.value" *ngFor="let option of self.locals.selection.field_spacings">{{ option.label }}</option>
                             </select>
                           </div>
+                        </div>
+                        <div class="flex-col-12 bm-5">
+                          <label class="block-label">Overview</label>
+                          <label class="checkbox-inline">
+                            <input type="checkbox" title="Overview" (ngModelChange)="self.touch()" [(ngModel)]="field.overview">
+                            Show on overview?
+                          </label>
                         </div>
                         <div class="flex-col-12 bm-5" *ngIf="field.input_type === 'formula'">
                           <label class="control-label">Formula</label>

--- a/src/app/pages/rpg-sheets/rpg-sheets.component.html
+++ b/src/app/pages/rpg-sheets/rpg-sheets.component.html
@@ -1,6 +1,6 @@
 <div class="container display-sheet sheet-rpg use-tabs help-on">
 
-  <header class="left-tabs" [ngClass]="self.locals.tabs.showing_nav ? 'showing-nav' : ''">
+  <header class="left-tabs" [class.showing-nav]="self.locals.tabs.showing_nav">
     <div class="visible-bar flex-row-all flex-config-align-center flex-gutters-5" (click)="self.methods.toggleNav()">
       <div class="flex-col">
         <button class="toggle-nav">
@@ -47,7 +47,7 @@ STRUCTURE TAB
 
       <div class="tab" [class.active]="self.methods.isTabActive('structure')">
         <div class="nav-slider">
-          <div class="slide" [ngClass]="self.methods.anyActiveTab() ? 'past' : 'present'">
+          <div class="slide" [class.past]="self.methods.anyActiveTab()">
             <h2 class="gh2">Tabs</h2>
             <p class="help-text">Tabs separate data into different pages. Tabs are containers where sections live. When you add a new tab, you will see it show up in the navigation for this sheet.</p>
             <div class="bm-20" cdkDropList [cdkDropListData]="self.model.tabs" (cdkDropListDropped)="self.methods.onSortableDrop($event)">
@@ -68,7 +68,7 @@ STRUCTURE TAB
             <button class="g-add" (click)="self.methods.addTab()"><i class="material-icons">add</i></button>
           </div>
 
-          <div class="slide" [ngClass]="self.methods.anyActiveTab() ? 'present' : 'future'">
+          <div class="slide" [class.present]="self.methods.anyActiveTab()">
             <div *ngFor="let tab of self.methods.structureTabInArray()">
               <div>
                 <h2 class="gh2"><span>{{ tab.name }}</span> Sections Layout</h2>
@@ -213,7 +213,7 @@ CONTENT TAB
                     <input type="text" placeholder="Name" (ngModelChange)="self.methods.sanitizeAspectName(calc)" [(ngModel)]="calc.name" class="form-control">
                   </div>
                   <div class="flex-col-8 flex-dynamic">
-                    <input type="text" placeholder="Formula" (ngModelChange)="self.methods.onCalculationChange(calc)" [(ngModel)]="calc.formula" class="form-control" [ngClass]="calc.valid ? 'valid-formula' : 'invalid-formula'">
+                    <input type="text" placeholder="Formula" (ngModelChange)="self.methods.onCalculationChange(calc)" [(ngModel)]="calc.formula" class="form-control" [class.invalid-formula]="!calc.valid">
                   </div>
                   <div class="flex-col flex-static">
                     <button class="g-remove" (click)="self.methods.removeEntity(self.model.calculations, calc)"><i class="material-icons">delete</i></button>
@@ -375,7 +375,7 @@ CONTENT TAB
                         </div>
                         <div class="flex-col-12 bm-5" *ngIf="field.input_type === 'formula'">
                           <label class="control-label">Formula</label>
-                          <input type="text" placeholder="Formula" (ngModelChange)="self.methods.validateCollectableFormula(field, collectable)" [(ngModel)]="field.formula" class="form-control" [ngClass]="field.valid ? 'valid-formula' : 'invalid-formula'">
+                          <input type="text" placeholder="Formula" (ngModelChange)="self.methods.validateCollectableFormula(field, collectable)" [(ngModel)]="field.formula" class="form-control" [class.invalid-formula]="!field.valid">
                           <div class="g-error tm-5" *ngIf="!field.valid">{{ field.error }}</div>
                         </div>
                       </div>

--- a/src/app/pages/rpg-sheets/rpg-sheets.component.html
+++ b/src/app/pages/rpg-sheets/rpg-sheets.component.html
@@ -34,18 +34,9 @@ OVERVIEW TAB
 -->
 
       <div class="tab overview-tab" [class.active]="self.methods.isTabActive('overview')">
-        <div class="overview-display-tab" *ngFor="let tab of self.methods.listTabs() ">
+        <div class="overview-display-tab" *ngFor="let tab of self.methods.listTabs()">
           <div class="flex-row-tablet flex-gutters-15 flex-config-wrap">
-            <div class="overview-display-section section" *ngFor="let section of self.methods.listTabSectionsForOverview(tab)" [ngClass]="self.methods.getTabSectionClass(section)">
-              <div *ngFor="let entity of self.methods.listEntitiesByGrouping(tab.id, section.id)">
-                <div [ngSwitch]="self.methods.getEntityType(entity)">
-                  <bt-rpg-overview-entity-calculation  [self]="self" [entity]="entity" *ngSwitchCase="'RpgCalculation'"></bt-rpg-overview-entity-calculation>
-                  <bt-rpg-overview-entity-collection   [self]="self" [entity]="entity" *ngSwitchCase="'RpgCollection'"></bt-rpg-overview-entity-collection>
-                  <bt-rpg-overview-entity-condition    [self]="self" [entity]="entity" *ngSwitchCase="'RpgCondition'"></bt-rpg-overview-entity-condition>
-                  <bt-rpg-overview-entity-stat         [self]="self" [entity]="entity" *ngSwitchCase="'RpgStat'"></bt-rpg-overview-entity-stat>
-                </div>
-              </div>
-            </div>
+            <bt-rpg-overview-tab [self]="self" [tab]="tab"></bt-rpg-overview-tab>
           </div>
         </div>
       </div>

--- a/src/app/pages/rpg-sheets/rpg-sheets.component.html
+++ b/src/app/pages/rpg-sheets/rpg-sheets.component.html
@@ -105,33 +105,52 @@ STRUCTURE TAB
                   <h2 class="gh2">Fields for section <span>{{ section.pos + 1 }}</span> of <span>{{ tab.name }}</span></h2>
                   <div class="structure-section-fields"
                     cdkDropList
-                    [cdkDropListData]="self.methods.listEntitiesBySection(section)"
-                    (cdkDropListDropped)="self.methods.onMoveList(tab.id, section.id, $event)"
+                    [cdkDropListData]="section"
+                    (cdkDropListDropped)="self.methods.onMoveList($event)"
                   >
                     <p *ngIf="!self.methods.anyEntitiesBySection(section)" class="p3">There are no fields assigned to this section. Drag fields into here!</p>
-                    <div class="structure-field js-structure-field flex-row-all flex-config-spaced flex-config-align-center" *ngFor="let entity of self.methods.listEntitiesBySection(section)" cdkDrag [cdkDragData]="entity">
-                      <!-- todo:  [data-id]="entity.id" [data-entity-type]="self.methods.getEntityType(entity)" -->
-                      <span class="name">{{ entity.name }}</span>
-                      <span class="info">{{ self.methods.getEntityInfo(entity) }}</span>
+                    <div class="structure-field js-structure-field flex-row-all flex-gutters-5 flex-config-align-center"
+                      *ngFor="let entity of self.methods.listEntitiesBySection(section)"
+                      cdkDrag
+                      [cdkDragData]="entity"
+                    >
+                      <div class="flex-col flex-dynamic">
+                        <span class="name">{{ entity.name }}</span>
+                      </div>
+                      <div class="flex-col flex-dynamic text-right">
+                        <span class="info">{{ self.methods.getEntityInfo(entity) }}</span>
+                      </div>
+                      <div class="flex-col flex-static">
+                        <button class="g-remove" (click)="self.methods.removeEntityFromSection(entity, section)"><i class="material-icons">delete</i></button>
+                      </div>
                     </div>
                   </div>
                 </div>
                 <div class="flex-col-6">
-                  <h2 class="gh2">Unassigned Fields</h2>
+                  <h2 class="gh2">Available Fields</h2>
+
+                  <label class="checkbox-inline bm-15">
+                    <input type="checkbox" title="Show only unassigned" (ngModelChange)="self.touch()" [(ngModel)]="self.locals.only_unassigned">
+                    Show only unassigned
+                  </label>
+
                   <div class="structure-section-fields"
                     cdkDropList
-                    (cdkDropListDropped)="self.methods.onMoveList(null, null, $event)"
-                    [cdkDropListData]="self.methods.listEntitiesBySection()"
+                    (cdkDropListDropped)="self.methods.onMoveList($event)"
                   >
-                    <p *ngIf="!self.methods.anyEntitiesBySection()" class="p3">There are no unassigned fields. Create more on the Content tab or reassign from a different section.</p>
-                    <div class="structure-field js-structure-field flex-row-all flex-config-spaced flex-config-align-center" *ngFor="let entity of self.methods.listEntitiesBySection(null)" cdkDrag [cdkDragData]="entity">
-                      <!-- todo:  [data-id]="entity.id" [data-entity-type]="self.methods.getEntityType(entity)" -->
-                      <span class="name">{{ entity.name }}</span>
-                      <span class="info">{{ self.methods.getEntityInfo(entity) }}</span>
+                    <p *ngIf="!self.methods.anyAvailableEntities()" class="p3">There are no available fields. <ng-container *ngIf="self.locals.only_unassigned">Uncheck the above checkbox to see all available fields. </ng-container>Create more on the Content tab or reassign from a different section.</p>
+                    <div class="structure-field js-structure-field flex-row-all flex-gutters-5 flex-config-align-center"
+                      *ngFor="let entity of self.methods.listAvailableEntities()"
+                      cdkDrag
+                      [cdkDragData]="entity"
+                    >
+                      <div class="flex-col flex-dynamic">
+                        <span class="name">{{ entity.name }}</span>
+                      </div>
+                      <div class="flex-col flex-dynamic text-right">
+                        <span class="info">{{ self.methods.getEntityInfo(entity) }}</span>
+                      </div>
                     </div>
-                  </div>
-                  <div class="tm-20 text-center">
-                    <button class="button button-red" (click)="self.methods.unassignAllEntities()">Unassign All Fields</button>
                   </div>
                 </div>
               </div>
@@ -179,7 +198,7 @@ CONTENT TAB
                 </div>
 
                 <div class="flex-col flex-static" *ngIf="self.model.stats.length > 1">
-                  <button class="g-remove" (click)="self.methods.removeByObject(self.model.stats, stat)"><i class="material-icons">delete</i></button>
+                  <button class="g-remove" (click)="self.methods.removeEntity(self.model.stats, stat)"><i class="material-icons">delete</i></button>
                 </div>
               </div>
               <button class="g-add" (click)="self.methods.addStat()"><i class="material-icons">add</i></button>
@@ -197,7 +216,7 @@ CONTENT TAB
                     <input type="text" placeholder="Formula" (ngModelChange)="self.methods.onCalculationChange(calc)" [(ngModel)]="calc.formula" class="form-control" [ngClass]="calc.valid ? 'valid-formula' : 'invalid-formula'">
                   </div>
                   <div class="flex-col flex-static">
-                    <button class="g-remove" (click)="self.methods.removeByObject(self.model.calculations, calc)"><i class="material-icons">delete</i></button>
+                    <button class="g-remove" (click)="self.methods.removeEntity(self.model.calculations, calc)"><i class="material-icons">delete</i></button>
                   </div>
                 </div>
                 <div class="g-error" *ngIf="!calc.valid">{{ calc.value }}</div>
@@ -229,7 +248,7 @@ CONTENT TAB
                     </div>
                   </div>
                   <div class="flex-col flex-static" *ngIf="self.model.collections.length > 1">
-                    <button class="g-remove" (click)="self.methods.removeByObject(self.model.collections, collection)"><i class="material-icons">delete</i></button>
+                    <button class="g-remove" (click)="self.methods.removeEntity(self.model.collections, collection)"><i class="material-icons">delete</i></button>
                   </div>
                 </div>
 
@@ -246,7 +265,7 @@ CONTENT TAB
                     <input type="text" placeholder="Condition name" (ngModelChange)="self.touch()" [(ngModel)]="condition.name" class="form-control" [disabled]="condition.active">
                   </div>
                   <div class="flex-col flex-static">
-                    <button class="g-remove" (click)="self.methods.removeByObject(self.model.conditions, condition)"><i class="material-icons">delete</i></button>
+                    <button class="g-remove" (click)="self.methods.removeEntity(self.model.conditions, condition)"><i class="material-icons">delete</i></button>
                   </div>
                 </div>
 
@@ -390,6 +409,7 @@ USER MODEL TAB
               <bt-rpg-entity-collection   [self]="self" [entity]="entity" *ngSwitchCase="'RpgCollection'"></bt-rpg-entity-collection>
               <bt-rpg-entity-condition    [self]="self" [entity]="entity" *ngSwitchCase="'RpgCondition'"></bt-rpg-entity-condition>
               <bt-rpg-entity-stat         [self]="self" [entity]="entity" *ngSwitchCase="'RpgStat'"></bt-rpg-entity-stat>
+              <ng-container *ngSwitchDefault>No known input for this type</ng-container>
             </div>
           </div>
         </div>

--- a/src/app/services/battlemap.service.ts
+++ b/src/app/services/battlemap.service.ts
@@ -333,7 +333,6 @@ export class BattlemapService {
     }
 
     self.methods.avaialbleSheetsByType = (type: string) => {
-      console.log(self.locals.available_tools)
       return self.locals.available_tools.filter(x => x.tool_type === type)
     }
 
@@ -342,6 +341,7 @@ export class BattlemapService {
     }
 
     self.methods.updateConnectedCombatant = (combatant: BattlemapCombatant, sheet: any): void => {
+      // TODO, this stuff only works for D&D and pathfinder, make it work for RPG too
       const token = self.methods.tokenForCombatant(combatant)
       if (token) {
         token.label = sheet.model.name

--- a/src/app/services/battlemap.service.ts
+++ b/src/app/services/battlemap.service.ts
@@ -341,17 +341,22 @@ export class BattlemapService {
     }
 
     self.methods.updateConnectedCombatant = (combatant: BattlemapCombatant, sheet: any): void => {
-      // TODO, this stuff only works for D&D and pathfinder, make it work for RPG too
       const token = self.methods.tokenForCombatant(combatant)
+      const sheetType = sheet.model.constructor.name
       if (token) {
         token.label = sheet.model.name
-        token.image = sheet.model.basic.image || token.image
       }
       combatant.name = sheet.model.name
-      combatant.stats.damage = sheet.model.combat.hp.damage
-      combatant.stats.hp = sheet.methods.getHPTotal()
-      combatant.stats.init = sheet.model.combat.init.value
-      // token.size = sheet.model.basic.size
+
+      if (sheetType === 'PathfinderCharacter' || sheetType === 'Dnd5eCharacter') {
+        if (token) {
+          token.image = sheet.model.basic.image || token.image
+        }
+        combatant.stats.damage = sheet.model.combat.hp.damage
+        combatant.stats.hp = sheet.methods.getHPTotal()
+        combatant.stats.init = sheet.model.combat.init.value
+        // token.size = sheet.model.basic.size
+      }
     }
 
     self.methods.combatantConnected = (combatant: BattlemapCombatant): boolean => {

--- a/src/app/services/migration.service.ts
+++ b/src/app/services/migration.service.ts
@@ -353,7 +353,9 @@ export class MigrationService {
           }
         },
       },
-      rpg: {},
+      rpg: {
+        0: async () => {}
+      },
       'homebrew-kit': {},
       battlemap: {
         15: async (model: any) => {

--- a/src/app/services/migration.service.ts
+++ b/src/app/services/migration.service.ts
@@ -357,7 +357,7 @@ export class MigrationService {
         1: async (model: any) => {
           // Move relational ids to containers
           const tabs = (model.tabs || [])
-          const sections = tabs.reduce((acc, tab) => [...acc, ...tab.sections], [])
+          const sections = tabs.reduce((acc, tab) => [...acc, ...(tab.sections || [])], [])
           sections.forEach(section => section.entity_ids = [])
           const entities = [
             ...(model.stats || []),

--- a/src/app/services/migration.service.ts
+++ b/src/app/services/migration.service.ts
@@ -354,7 +354,22 @@ export class MigrationService {
         },
       },
       rpg: {
-        0: async () => {}
+        1: async (model: any) => {
+          // Move relational ids to containers
+          const tabs = (model.tabs || [])
+          const sections = tabs.reduce((acc, tab) => [...acc, ...tab.sections], [])
+          sections.forEach(section => section.entity_ids = [])
+          const entities = [
+            ...(model.stats || []),
+            ...(model.calculations || []),
+            ...(model.collections || []),
+            ...(model.conditions || []),
+          ]
+          entities.forEach(entity => {
+            const section = sections.find(x => x.id === entity.section)
+            section.entity_ids.push(entity.id)
+          })
+        },
       },
       'homebrew-kit': {},
       battlemap: {

--- a/src/app/services/rpg.service.ts
+++ b/src/app/services/rpg.service.ts
@@ -270,11 +270,6 @@ export class RpgService {
     self.methods.removeTab = (tab: RpgTab, e: MouseEvent): void => {
       e.stopPropagation()
 
-      self.methods.listEntitiesByTab(tab.id).forEach((entity: RpgCalculation|RpgCondition|RpgCollection|RpgStat) => {
-        entity.tab = null
-        entity.section = null
-      })
-
       if (self.methods.anyActiveTab() && self.locals.data.structure_tab.id === tab.id) {
         self.methods.setStructureTab(null)
       }
@@ -309,11 +304,6 @@ export class RpgService {
 
     self.methods.removeTabSection = (tab: RpgTab, section: RpgTabSection, e: MouseEvent): void => {
       e.stopPropagation()
-
-      self.methods.listEntitiesBySection(section.id).forEach(entity => {
-        entity.tab = null
-        entity.section = null
-      })
 
       if (self.methods.anyActiveSection() && self.locals.data.structure_section.id === tab.id) {
         self.methods.setStructureSection(null)
@@ -428,14 +418,26 @@ export class RpgService {
     }
 
     self.methods.listEntitiesByObject = (object: any): (RpgCalculation|RpgCondition|RpgCollection|RpgStat)[] => {
-      let items = [...self.methods.listStats(), ...self.methods.listCalculations(), ...self.methods.listCollections(), ...self.methods.listConditions()].filter(item => byObjectPredicate(item, object))
+      const items = [
+        ...self.methods.listStats(),
+        ...self.methods.listCalculations(),
+        ...self.methods.listCollections(),
+        ...self.methods.listConditions()
+      ].filter(item => byObjectPredicate(item, object))
       return items.sort((a, b) => a.pos - b.pos)
     }
 
-    self.methods.listEntitiesByTab = (tabId: string): (RpgCalculation|RpgCondition|RpgCollection|RpgStat)[] => self.methods.listEntitiesByObject({ tab: tabId })
-    self.methods.listEntitiesBySection = (sectionId: string): (RpgCalculation|RpgCondition|RpgCollection|RpgStat)[] => self.methods.listEntitiesByObject({ section: sectionId })
-    self.methods.listEntitiesByGrouping = (tabId: string, sectionId: RpgTabSection): (RpgCalculation|RpgCondition|RpgCollection|RpgStat)[] => self.methods.listEntitiesByObject({ tab: tabId, section: sectionId })
-    self.methods.anyEntitiesByGrouping = (tabId: string, sectionId: RpgTabSection): boolean => self.methods.listEntitiesByGrouping(tabId, sectionId).length > 0
+    self.methods.listEntitiesBySection = (section: RpgTabSection): (RpgCalculation|RpgCondition|RpgCollection|RpgStat)[] => {
+      if (!section || !section.entity_ids) { return [] }
+      const items = [
+        ...self.methods.listStats(),
+        ...self.methods.listCalculations(),
+        ...self.methods.listCollections(),
+        ...self.methods.listConditions()
+      ]
+      return items.filter(item => section.entity_ids.includes(item.id)).sort((a, b) => a.pos - b.pos)
+    }
+    self.methods.anyEntitiesBySection = (section: RpgTabSection): boolean => self.methods.listEntitiesBySection(section).length > 0
 
     self.methods.listEntitiesForConditionEffect = (): (RpgCalculation|RpgCondition|RpgCollection|RpgStat)[] => {
       const stats = self.methods.listStats().filter(x => x.input_type === 'number')

--- a/src/app/services/rpg.service.ts
+++ b/src/app/services/rpg.service.ts
@@ -207,7 +207,7 @@ export class RpgService {
     }
 
     self.methods.listAllTabs = () => {
-      return [...self.locals.tabs.list, ...self.methods.listTabs()]
+      return [...self.locals.tabs.list, ...self.methods.listIncludedTabs()]
     }
 
     const finishedLoading = (): void => {
@@ -261,6 +261,7 @@ export class RpgService {
     // Tabs
     // ---------------------------------------------------
     self.methods.listTabs = (): RpgTab[] => self.model.tabs || []
+    self.methods.listIncludedTabs = (): RpgTab[] => self.methods.listTabs().filter(x => x.name !== 'Battlemap')
 
     self.methods.addTab = (): void => {
       self.methods.$add(self.model, 'tabs', RpgTab, {
@@ -378,6 +379,7 @@ export class RpgService {
     // Collectable Field
     // ---------------------------------------------------
     self.methods.listCollectableFields = (collectable: RpgCollectable): RpgCollectableField[] => collectable.fields || []
+    self.methods.listCollectableFieldsForOverview = (collectable: RpgCollectable): RpgCollectableField[] => self.methods.listCollectableFields(collectable).filter(x => x.overview)
 
     self.methods.addCollectableField = (collectable: RpgCollectable): void => {
       self.methods.$add(collectable, 'fields', RpgCollectableField, {
@@ -422,7 +424,7 @@ export class RpgService {
         ...self.methods.listCalculations(),
         ...self.methods.listCollections(),
         ...self.methods.listConditions()
-      ].sort((a, b) => a.pos - b.pos)
+      ]
     }
 
     self.methods.listEntitiesByObject = (object: any): (RpgCalculation|RpgCondition|RpgCollection|RpgStat)[] => {
@@ -560,7 +562,7 @@ export class RpgService {
       active: (self.locals.data.structure_tab !== null) && tab.id === self.locals.data.structure_tab.id
     })
 
-    self.methods.getCollectableFieldClasses = (field: RpgCollectableField): string => `flex-${field.width} bm-${field.space}`
+    self.methods.getCollectableFieldClasses = (field: RpgCollectableField): string => `flex-${field.width} spacer-${field.space}`
     self.methods.anyActiveTab = (): boolean => self.locals.data.structure_tab !== null
     self.methods.anyActiveSection = (): boolean => self.locals.data.structure_section !== null
 

--- a/src/app/services/rpg.service.ts
+++ b/src/app/services/rpg.service.ts
@@ -63,7 +63,7 @@ export class RpgService {
           { label: '50%', value: 6 },
           { label: '100%', value: 12 },
           { label: '25%', value: 3 },
-          { label: '75%', value: 9 }
+          { label: '75%', value: 9 },
         ],
         input_types: [
           { label: 'Number', value: 'number', init: 0 },

--- a/src/app/services/rpg.service.ts
+++ b/src/app/services/rpg.service.ts
@@ -291,6 +291,10 @@ export class RpgService {
       self.locals.data.structure_section = null
     }
 
+    self.methods.battlemapTab = () => {
+      return self.methods.listTabs().find(x => x.name === 'Battlemap')
+    }
+
     // Tab Sections
     // ---------------------------------------------------
     self.methods.listTabSections = (tab: RpgTab): RpgTabSection[] => tab.sections || []

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1712,16 +1712,17 @@ input[type=checkbox].match-text-field {
   position: relative;
   .structure-field {
     background: white;
-    padding: 10px 20px;
+    padding: 10px 8px 10px 15px;
     border-radius: 20px;
     margin-bottom: 10px;
-    box-shadow: 0 rem(1) rem(3) rgba(0,0,0,.2);
+    box-shadow: 0 1px 3px rgba(0,0,0,.2);
     .name {
       font-family: $title;
       @include header-size(16, 16, 15, 14, 1.2);
     }
     .info {
       color: #888;
+      text-align: right;
     }
     // border: 1px solid $border-color;
   }

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1742,6 +1742,32 @@ input[type=checkbox].match-text-field {
   }
 }
 
+.sheet-rpg {
+  .rpg-collection {
+    margin-bottom: 20px;
+    .above-labels {
+      margin-bottom: 5px;
+    }
+    .collection-item {
+      margin-bottom: 10px;
+    }
+    @each $space in (5, 10, 15, 20) {
+      .spacer-#{$space} {
+        margin-bottom: #{$space}px;
+      }
+    }
+  }
+  .rpg-collection-edit {
+    margin-bottom: 40px;
+  }
+}
+
+.rpg-calculation, .rpg-stat, .rpg-condition {
+  .sheet-rpg & {
+    margin-bottom: 10px;
+  }
+}
+
 .block-value {
   padding: 7px 0;
 }
@@ -2462,6 +2488,33 @@ $bg-opacity: 0.075;
   }
   
 }
+
+.sheet-card .overview-display-section {
+  .block-label, .block-value {
+    padding: 0;
+    margin: 0;
+  }
+  .button {
+    background: $cyan-color;
+    padding: 2px 0;
+    border: 0;
+    color: white;
+    border-radius: 4px;
+    line-height: 1.2;
+    width: 50px;
+    display: block;
+    text-align: center;
+    &:hover {
+      background: lighten($cyan-color, 5%)
+    }
+  }
+  .rpg-collection {
+   .gh4 {
+     margin-bottom: 0;
+   }
+  }
+}
+
 .viewport {
   background: #DDD;
   position: absolute;


### PR DESCRIPTION
* Allows RPG sheets to be connected to battlemap tokens
* Allows fields to be included in more than one section at a time
* Includes new special Tab called `"Battlemap"` which is where you determine what will display on the Battlemap active card for connected tokens
* Adds new checkbox on RPG sheets collectable fields which can include or exclude certain fields from showing on the overview page
* UI updates